### PR TITLE
Updated to sysnative

### DIFF
--- a/_posts/2016-06-06-vscode-terminal.markdown
+++ b/_posts/2016-06-06-vscode-terminal.markdown
@@ -11,7 +11,7 @@ I personally use PowerShell for all of my CLI needs in Windows, as it has a bett
 To do this, open up your user settings and add the following to your settings configuration...
 
 ```json
-"terminal.integrated.shell.windows": "\\windows\\system32\\WindowsPowerShell\\v1.0\\powershell.exe"
+"terminal.integrated.shell.windows": "C:\\windows\\sysnative\\WindowsPowerShell\\v1.0\\powershell.exe"
 ```
 
 Open up the integrated terminal and there it is!  PowerShell is now my integrated terminal in VS Code.


### PR DESCRIPTION
I'm not 100% sure but shouldn't this be sysnative instead of system32 in order to use the 64-bit version of PowerShell?
